### PR TITLE
Let Rustls consumers choose the crypto provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1763,7 +1763,6 @@ version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -1837,7 +1836,6 @@ version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ native-tls = { version = "^0.2", optional = true }
 tokio-native-tls = { version = "^0.3", optional = true }
 
 # TLS support via rustls
-tokio-rustls = { version = "^0.26", optional = true }
+tokio-rustls = { version = "^0.26", default-features = false, features = ["logging", "tls12"], optional = true }
 webpki-roots = { version = "^1.0", optional = true }
 rustls-native-certs = { version = "^0.8", optional = true }
 rustls-platform-verifier = { version = "^0.6", optional = true }
@@ -204,7 +204,7 @@ http = { version = "^1.0", optional = true }
 quinn = { version = "^0.11", optional = true }
 h3 = { version = "^0.0.8", optional = true }
 h3-quinn = { version = "^0.0.10", optional = true }
-rustls = { version = "^0.23", default-features = false, features = ["ring", "std"], optional = true }
+rustls = { version = "^0.23", default-features = false, features = ["std"], optional = true }
 
 # High-performance allocator
 mimalloc = { version = "^0.1", default-features = false, optional = true }
@@ -224,6 +224,7 @@ axum = "^0.8"
 hyper = { version = "^1.0", features = ["full"] }
 hyper-util = { version = "^0.1", features = ["tokio"] }
 rcgen = "^0.13"
+rustls = { version = "^0.23", default-features = false, features = ["ring", "std"] }
 rustls-pemfile = "^2.0"
 
 [[example]]

--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ sockudo-ws = { git = "https://github.com/sockudo/sockudo-ws", default-features =
 
 # With TLS (rustls)
 sockudo-ws = { git = "https://github.com/sockudo/sockudo-ws", features = ["rustls-webpki-roots"] }
+rustls = { version = "0.23", default-features = false, features = [
+    "aws-lc-rs",
+    "logging",
+    "std",
+    "tls12",
+] }
 
 # With TLS (native-tls)
 sockudo-ws = { git = "https://github.com/sockudo/sockudo-ws", features = ["native-tls"] }
@@ -798,6 +804,10 @@ streams inherit the state machine from their runtime WebSocket stream.
 | `rustls-webpki-roots` | TLS via tokio-rustls with webpki-roots |
 | `rustls-native-roots` | TLS via tokio-rustls with native root certificates |
 | `rustls-platform-verifier` | TLS via tokio-rustls with platform verifier |
+
+Rustls features do not select a crypto provider. Applications must enable
+exactly one provider, such as `aws-lc-rs` or `ring`, on their direct `rustls`
+dependency.
 
 ### SHA-1 Implementations
 


### PR DESCRIPTION
### Summary

Stop selecting a Rustls crypto provider in Sockudo's normal TLS dependency graph. Applications can
now use `rustls-webpki-roots`, `rustls-native-roots`, or `rustls-platform-verifier` while choosing
Ring, AWS‑LC, or a custom provider through their direct `rustls` dependency.

Sockudo keeps TLS 1.2 and logging enabled on `tokio-rustls`. Its tests select Ring through a dev
dependency, so existing TLS and HTTP/3 coverage continues to run without imposing that choice on
ordinary TLS consumers.

### Design

- Disable `tokio-rustls` default features because they select AWS‑LC, then explicitly retain its
  existing `logging` and `tls12` features.
- Keep only `std` on the normal optional `rustls` dependency instead of forcing Ring.
- Let applications enable exactly one provider through their own `rustls` dependency, matching
  Rustls's process‑level provider model.
- Enable Ring on the `rustls` dev dependency for Sockudo's existing tests.
- Leave HTTP/3 provider behavior unchanged. Quinn and Compio still select Ring for HTTP/3, which is
  separate from the ordinary Tokio Rustls connector changed here.

### Changes

- Make the normal `rustls` and `tokio-rustls` dependencies provider‑neutral.
- Move Sockudo's Ring selection to dev scope.
- Document downstream provider selection with an AWS‑LC example.
- Refresh the lockfile after removing AWS‑LC from the normal Sockudo feature set.

### Consumer configuration

Applications can select AWS‑LC without compiling Ring:

```toml
sockudo-ws = { version = "2.0.1", default-features = false, features = ["tokio-runtime", "rustls-webpki-roots"] }
rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "logging", "std", "tls12"] }
```

Applications that prefer Ring can enable `rustls/ring` instead. Custom providers can be installed
through Rustls without Sockudo adding either built‑in provider to the normal graph.

### Commit and branch

- Branch: `fix/configurable-rustls-provider`.
- Commit: `8d2d625327fd48491bb4fb3e81f78d94978246bb Let Rustls consumers choose the crypto provider`.
- Base: `0d7e79c2501a384d38ba767c520d5e1eb05e46ea` (`origin/master`).
- Shape: exactly one commit ahead of `origin/master`.
- Remote: `faysou:fix/configurable-rustls-provider`.
- PR: [sockudo/sockudo-ws#11](https://github.com/sockudo/sockudo-ws/pull/11).

### Verification

- `cargo check --offline --locked --no-default-features --features rustls-webpki-roots` passed.
- The matching normal dependency graph contains neither Ring nor AWS‑LC.
- A disposable downstream consumer with direct `rustls/aws-lc-rs` compiled and its normal graph
  contains AWS‑LC with no Ring.
- A disposable NautilusTrader worktree using this local Sockudo fork has no normal reverse
  dependency on Ring and retains AWS‑LC through NautilusTrader's direct Rustls configuration.
- `cargo test --offline --locked --all-features --test e2e_runtime_transports` passed all Tokio and
  Compio HTTP/1, HTTP/2, and HTTP/3 tests.
- `cargo fmt --all -- --check` and `git diff --check origin/master..HEAD` passed.
- `markdownlint-cli2 README.md` remains blocked by 158 pre‑existing README violations; none point to
  the newly added provider‑selection lines.
